### PR TITLE
Add "wire" length statistics

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -163,9 +163,11 @@ static inline void log_stats(dagstreamthread_t *dst, struct timeval now) {
                  "walked_buffers %"PRIu64"\n"
                  "walked_records %"PRIu64"\n"
                  "walked_bytes %"PRIu64"\n"
+                 "walked_wire_bytes %"PRIu64"\n"
                  "tx_datagrams %"PRIu64"\n"
                  "tx_records %"PRIu64"\n"
                  "tx_bytes %"PRIu64"\n"
+                 "tx_wire_bytes %"PRIu64"\n"
                  "dropped_records %"PRIu64"\n"
                  "truncated_records %"PRIu64"\n",
                  (int)now.tv_sec,
@@ -174,9 +176,11 @@ static inline void log_stats(dagstreamthread_t *dst, struct timeval now) {
                  dst->stats.walked_buffers,
                  dst->stats.walked_records,
                  dst->stats.walked_bytes,
+                 dst->stats.walked_wbytes,
                  dst->stats.tx_datagrams,
                  dst->stats.tx_records,
                  dst->stats.tx_bytes,
+                 dst->stats.tx_wbytes,
                  dst->stats.dropped_records,
                  dst->stats.truncated_records);
         wandio_wwrite(logf, buf, strlen(buf));
@@ -187,9 +191,11 @@ static inline void log_stats(dagstreamthread_t *dst, struct timeval now) {
                 "walked_buffers:%"PRIu64" "
                 "walked_records:%"PRIu64" "
                 "walked_bytes:%"PRIu64" "
+                "walked_wire_bytes:%"PRIu64" "
                 "tx_datagrams:%"PRIu64" "
-                "tx_bytes:%"PRIu64" "
                 "tx_records:%"PRIu64" "
+                "tx_bytes:%"PRIu64" "
+                "tx_wire_bytes:%"PRIu64" "
                 "dropped_records:%"PRIu64" "
                 "truncated_records %"PRIu64"\n",
                 (int)now.tv_sec,
@@ -197,9 +203,11 @@ static inline void log_stats(dagstreamthread_t *dst, struct timeval now) {
                 dst->stats.walked_buffers,
                 dst->stats.walked_records,
                 dst->stats.walked_bytes,
+                dst->stats.walked_wbytes,
                 dst->stats.tx_datagrams,
                 dst->stats.tx_records,
                 dst->stats.tx_bytes,
+                dst->stats.tx_wbytes,
                 dst->stats.dropped_records,
                 dst->stats.truncated_records);
     }

--- a/src/dagmultiplexer.h
+++ b/src/dagmultiplexer.h
@@ -33,11 +33,13 @@ typedef struct streamstats {
     uint64_t walked_buffers; // number of stream buffers walked
     uint64_t walked_records; // number of ERF records (packets) walked
     uint64_t walked_bytes; // number of bytes walked
+    uint64_t walked_wbytes; // number of "wire" bytes walked (excl. ERF headers)
 
     /* nDAG transmit stats */
     uint64_t tx_datagrams; // number of multicast datagrams tx'd
     uint64_t tx_records; // number of ERF records (packets) tx'd
     uint64_t tx_bytes; // number of bytes tx'd
+    uint64_t tx_wbytes; // number of "wire" bytes tx'd (excl. ERF headers)
 
     /* error stats */
     uint64_t dropped_records; // number of records dropped (according to DAG)


### PR DESCRIPTION
This will give us visibility into the amount of telescope traffic being captured rather than the amount of data being received from the DAG card and/or transmitted on the multicast group. That is, these statistics remove the overhead of the ERF headers.