### PR TITLE
Fix endless stat message spamming if the stat interval is zero

### DIFF
--- a/src/dagmultiplexer.c
+++ b/src/dagmultiplexer.c
@@ -291,7 +291,7 @@ void dag_stream_loop(dagstreamthread_t *dst, ndag_encap_params_t *state,
         // Should we log stats now?
         // TODO: consider checking the time every N iterations
         gettimeofday(&now, NULL);
-        if (now.tv_sec >= nextstat) {
+        if (nextstat > 0 && now.tv_sec >= nextstat) {
             log_stats(dst, now);
             nextstat += dst->params.statinterval;
         }

--- a/wdcapsniffer/dagmultiplexer.c
+++ b/wdcapsniffer/dagmultiplexer.c
@@ -238,7 +238,7 @@ void dag_stream_loop(dagstreamthread_t *dst, ndag_encap_params_t *state,
         // should we log stats now?
         // TODO: consider checking the time every N iterations
         gettimeofday(&now, NULL);
-        if (now.tv_sec >= nextstat) {
+        if (nextstat > 0 && now.tv_sec >= nextstat) {
             log_stats(dst, now);
             nextstat += dst->params.statinterval;
         }

--- a/wdcapsniffer/wdcapsniffer.c
+++ b/wdcapsniffer/wdcapsniffer.c
@@ -300,6 +300,7 @@ int main(int argc, char **argv) {
      */
 
     params.monitorid = 1;
+    params.statinterval = 0;
 
     /* This lets us do fast polling on the DAG card. Fast polls (< 2ms) will
      * be implemented as busy-waits so there will be high CPU usage.


### PR DESCRIPTION
 * don't perform stat log check if `nextstat` is zero (i.e. not set due to a zero stat interval).
 * make sure wdcapsniffer initialises the stat interval to zero to avoid uninitialised variable shenanigans.