### PR TITLE
Allow libndag-server to be built stand-alone

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,9 @@ fi
 
 if test "$dag_found" = 0; then
         AC_MSG_ERROR(Required library libdag not found; use LDFLAGS to specify library location)
+else
+        EXTRA_LIBS="$EXTRA_LIBS -ldag"
+        AC_DEFINE(HAVE_DAGAPI, 1, "Compiled with libdag support")
 fi
 
 if test "$dagconf_found" = 0; then

--- a/libndag-server/bootstrap.sh
+++ b/libndag-server/bootstrap.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+set -x
+aclocal-1.9 || aclocal 
+libtoolize --force --copy
+autoheader
+automake-1.9 --add-missing --copy --foreign ||
+        automake --add-missing --copy --foreign
+	
+autoconf

--- a/libndag-server/configure.ac
+++ b/libndag-server/configure.ac
@@ -1,0 +1,73 @@
+# Super primitive configure script
+
+AC_INIT(libndagserver, 0.0.1, salcock@wand.net.nz)
+
+AM_INIT_AUTOMAKE([subdir-objects])
+AC_CONFIG_SRCDIR(ndagmulticaster.c)
+AM_CONFIG_HEADER(config.h)
+AC_CONFIG_MACRO_DIR([../m4])
+
+m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
+
+AC_PREFIX_DEFAULT(/usr/local/)
+
+AC_PROG_CC
+AC_PROG_INSTALL
+
+AC_PROG_LIBTOOL
+
+gcc_PACKED
+
+AC_CHECK_LIB([trace], [trace_get_payload_length],,trace_found=0)
+AC_CHECK_LIB([wandio], [wandio_create],,wandio_found=0)
+AC_CHECK_LIB([pthread], [pthread_create],,pthread_found=0)
+AC_CHECK_LIB([dag], [dag_attach_stream],dag_found=1,dag_found=0)
+#AC_CHECK_LIB([numa], [numa_node_of_cpu],,numa_found=0)
+
+EXTRA_LIBS=""
+
+
+AC_CHECK_FUNCS(sendmmsg)
+
+AC_CONFIG_FILES([Makefile])
+
+if test "$dag_found" = 1; then
+        EXTRA_LIBS="$EXTRA_LIBS -ldag"
+        AC_DEFINE(HAVE_DAGAPI, 1, "Compiled with libdag support")
+fi
+
+if test "$trace_found" = 0; then
+        AC_MSG_ERROR(Required library libtrace not found; use LDFLAGS to specify library location)
+fi
+
+if test "$wandio_found" = 0; then
+        AC_MSG_ERROR(Required library libwandio not found; use LDFLAGS to specify library location)
+fi
+
+if test "$pthread_found" = 0; then
+        AC_MSG_ERROR(Required library libpthread not found; use LDFLAGS to specify library location)
+fi
+
+if test "$numa_found" = 0; then
+        AC_MSG_ERROR(Required library libnuma not found; use LDFLAGS to specify library location)
+fi
+
+
+
+AC_SUBST([ADD_LIBS])
+AC_SUBST([EXTRA_LIBS])
+AC_SUBST([ADD_LDFLAGS])
+AC_SUBST([ADD_INCLS])
+AC_SUBST([LTLIBOBJS])
+
+AC_OUTPUT
+
+# Function for reporting whether an option was set or not
+reportopt() {
+        if test x"$2" = xtrue -o x"$2" = xyes; then
+                AC_MSG_NOTICE([$1: Yes])
+        else 
+                AC_MSG_NOTICE([$1: No])
+        fi
+}
+

--- a/libndag-server/ndagmulticaster.c
+++ b/libndag-server/ndagmulticaster.c
@@ -135,7 +135,7 @@ void ndag_close_multicaster_socket(int ndagsock, struct addrinfo *targetinfo) {
 
 void ndag_init_encap(ndag_encap_params_t *params, int sock,
         struct addrinfo *targetinfo, uint16_t monitorid, uint16_t streamid,
-        uint64_t start, uint16_t mtu, int compress) {
+        uint64_t start, uint16_t mtu, uint8_t encap_type, int compress) {
 
     int i, j;
 
@@ -145,6 +145,7 @@ void ndag_init_encap(ndag_encap_params_t *params, int sock,
     params->seqno = 1;
     params->starttime = start;
     params->maxdgramsize = mtu;
+    params->encap_type = encap_type;
     params->monitorid = monitorid;
     params->mmsgbufs = (struct mmsghdr *)calloc(sizeof(struct mmsghdr),
             NDAG_BATCH_SIZE);
@@ -212,7 +213,7 @@ uint16_t ndag_push_encap_iovecs(ndag_encap_params_t *params,
     int i;
 
     encap = (ndag_encap_t *)(populate_common_header(params->headerspace[index],
-            params->monitorid, NDAG_PKT_ENCAPERF));
+            params->monitorid, params->encap_type));
     encap->started = params->starttime;
     encap->seqno = htonl(params->seqno);
     encap->streamid = htons(params->streamnum);

--- a/libndag-server/ndagmulticaster.c
+++ b/libndag-server/ndagmulticaster.c
@@ -10,7 +10,6 @@
 #include <sys/socket.h>
 #include <errno.h>
 #include <unistd.h>
-#include <dagapi.h>
 #include <pthread.h>
 
 #include "byteswap.h"

--- a/libndag-server/ndagmulticaster.h
+++ b/libndag-server/ndagmulticaster.h
@@ -1,6 +1,14 @@
 #ifndef NDAGMULTICASTER_H_
 #define NDAGMULTICASTER_H_
 
+#include "config.h"
+
+#ifdef HAVE_DAGAPI
+#include <dagapi.h>
+#else
+#include <libtrace/dagformat.h>
+#endif
+
 #include <sys/socket.h>
 #include <stdlib.h>
 #include <sys/types.h>

--- a/libndag-server/ndagmulticaster.h
+++ b/libndag-server/ndagmulticaster.h
@@ -1,14 +1,7 @@
 #ifndef NDAGMULTICASTER_H_
 #define NDAGMULTICASTER_H_
 
-#include "config.h"
-
-#ifdef HAVE_DAGAPI
-#include <dagapi.h>
-#else
 #include <libtrace/dagformat.h>
-#endif
-
 #include <sys/socket.h>
 #include <stdlib.h>
 #include <sys/types.h>

--- a/libndag-server/ndagmulticaster.h
+++ b/libndag-server/ndagmulticaster.h
@@ -50,6 +50,7 @@ typedef struct ndagencapparams {
     struct addrinfo *target;
     uint64_t starttime;
     uint16_t maxdgramsize;
+    uint8_t encap_type;
 
     struct mmsghdr *mmsgbufs;
     char *headerspace[NDAG_BATCH_SIZE];
@@ -62,6 +63,7 @@ enum {
     //NDAG_PKT_RESTARTED = 0x03,
     NDAG_PKT_ENCAPRT = 0x04,
     NDAG_PKT_KEEPALIVE = 0x05,
+    NDAG_PKT_CORSAROTAG = 0x06,
 };
 
 /* == Protocol header structures == */
@@ -100,7 +102,7 @@ int ndag_send_keepalive(ndag_encap_params_t *params);
 
 void ndag_init_encap(ndag_encap_params_t *params, int sock,
         struct addrinfo *targetinfo, uint16_t monitorid, uint16_t streamid,
-        uint64_t start, uint16_t mtu, int compress);
+        uint64_t start, uint16_t mtu, uint8_t encap_type, int compress);
 void ndag_reset_encap_state(ndag_encap_params_t *params);
 uint16_t ndag_push_encap_iovecs(ndag_encap_params_t *params,
         struct iovec *iovecs, uint16_t num_iov, uint16_t reccount, int index);

--- a/src/dagmultiplexer.c
+++ b/src/dagmultiplexer.c
@@ -159,7 +159,7 @@ int init_dag_sink(ndag_encap_params_t *state, streamsink_t *params, int streamnu
     }
 
     ndag_init_encap(state, sock, targetinfo, params->monitorid, streamnum,
-        globalstart, params->mtu, 0);
+        globalstart, params->mtu, NDAG_PKT_ENCAPERF, 0);
     return sock;
 }
 

--- a/wdcapsniffer/dagmultiplexer.c
+++ b/wdcapsniffer/dagmultiplexer.c
@@ -140,7 +140,7 @@ int init_dag_stream(dagstreamthread_t *dst, ndag_encap_params_t *state) {
 
     ndag_init_encap(state, sock, targetinfo, dst->params.monitorid,
             dst->params.streamnum, dst->params.globalstart, dst->params.mtu,
-            0);
+            NDAG_PKT_ENCAPERF, 0);
     return sock;
 }
 


### PR DESCRIPTION
Now that corsaro3 depends on libndag-server, I've modified the structure of the build system to allow libndag-server to be built and installed stand-alone (i.e. without the telescope or wdcapsniffer tools).

This will allow us to build and distribute libndag-server packages, or allow source-build users to just build the libraries and not need to meet the dependencies of the tools (such as dag libraries, which aren't available to most users).